### PR TITLE
DBのオプションを修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,14 +39,15 @@ Things you may want to cover:
 - has_many :likes
 
 ## booksテーブル
-|Column       |Type       |Options                          |
-|-------------|-----------|---------------------------------|
-|user_id      |references |null: false, foreign_key: true   |
-|category_id  |references |null: false,                     |
-|title        |string     |null: false                      |
-|article      |text       |null: false                      |
-|image        |string     |null: false                      |
-|likes_count  |integer    |                                 |
+|Column           |Type       |Options                          |
+|-----------------|-----------|---------------------------------|
+|user_id          |references |null: false, foreign_key: true   |
+|category_id      |integer    |null: false                      |
+|book_title       |string     |null: false                      |
+|article          |text       |null: false                      |
+|image            |string     |null: false                      |
+|article_title    |string     |null: false                      |
+|likes_count      |integer    |                                 |
 ### Association
 - belongs_to :user
 - belongs_to :category
@@ -78,7 +79,7 @@ Things you may want to cover:
 |Column       |Type         |Options                          |
 |-------------|-------------|---------------------------------|
 |name         |string       |null: false, unique: true        |
-|ancestry     |string       |                                 |
+|ancestry     |string       |add_index: true                  |
 - has_many :books
 - has_ancestry
 

--- a/db/migrate/20201224115921_change_optioncategory_id_to_books.rb
+++ b/db/migrate/20201224115921_change_optioncategory_id_to_books.rb
@@ -1,0 +1,5 @@
+class ChangeOptioncategoryIdToBooks < ActiveRecord::Migration[6.0]
+  def change
+    change_column :books, :category_id, :integer, null: false
+  end
+end

--- a/db/migrate/20201224120907_change_option_article_title_to_books.rb
+++ b/db/migrate/20201224120907_change_option_article_title_to_books.rb
@@ -1,0 +1,5 @@
+class ChangeOptionArticleTitleToBooks < ActiveRecord::Migration[6.0]
+  def change
+    change_column :books, :article_title, :string, null: false
+  end
+end

--- a/db/migrate/20201224122005_change_option_name_to_categories.rb
+++ b/db/migrate/20201224122005_change_option_name_to_categories.rb
@@ -1,0 +1,5 @@
+class ChangeOptionNameToCategories < ActiveRecord::Migration[6.0]
+  def change
+    change_column :categories, :name, :string, null: false, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_22_124426) do
+ActiveRecord::Schema.define(version: 2020_12_24_122005) do
 
   create_table "books", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "book_title", null: false
@@ -18,12 +18,12 @@ ActiveRecord::Schema.define(version: 2020_12_22_124426) do
     t.string "image", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.integer "category_id"
-    t.string "article_title"
+    t.integer "category_id", null: false
+    t.string "article_title", null: false
   end
 
   create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "name"
+    t.string "name", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "ancestry"


### PR DESCRIPTION
# What
DBのオプションを修正
 - booksテーブルのcategories_idとarticle_titleにnull: falseを追加
 - categoriesテーブルのnameにnull: falseを追加
 - READMEの記述を修正

# Why
DBのオプションに不足があったため