### PR TITLE
詳細ページの修正と表示内容追加

### DIFF
--- a/app/assets/stylesheets/modules/_books_show.scss
+++ b/app/assets/stylesheets/modules/_books_show.scss
@@ -1,8 +1,22 @@
+@mixin like() {
+  .like-box {
+    padding: 20px 0;
+    font-size: 14px;
+    color: #e54747; 
+    &--color {
+      font-size: 14px;
+      color: #e54747;
+      display: inline;
+    }
+  }
+}
+
 .show-wrapper {
   height: 100vh;
   .show-main {
     width: 620px;
     margin: 80px auto 0;
+    padding-bottom: 150px;
     .book-info {
       display: flex;
       padding-bottom: 60px;
@@ -24,14 +38,15 @@
         }
         &--poster {
           font-size: 16px;
+          margin-bottom: 5px;
         }
         &--post-date {
           font-size: 12px;
-          padding-bottom: 20px;
+          padding-bottom: 30px;
         }
         &--review {
           font-size: 14px;
-          padding-bottom: 20px;
+          padding-bottom: 10px;
           display: inline-block;
         }
         &--point {
@@ -41,6 +56,9 @@
           color: #222;
           align-items: center;
           margin-left: 10px;
+        }
+        .like-btn {
+          @include like();
         }
       }
     }
@@ -58,18 +76,56 @@
         color: #222;
         padding-top: 40px;
       }
+      .like-btn {
+        @include like();
+      }
+    }
+    .recent {
+      margin-top: 10px;
+      padding: 20px 0;
+      border-top: 1px solid #f2f2f2;
+      border-bottom: 1px solid #f2f2f2;
+      .poster-name {
+        padding: 10px 0;
+        font-size: 14px;
+        font-weight: bold;
+        color: #222;
+      }
+      .recent-articles {
+        .article-box {
+          margin: 8px 0;
+          .article-container {
+            .article-info {
+              display: flex;
+              justify-content: space-between;
+              align-items: center;
+              .article-data {
+                &--title {
+                  color: #222;
+                  font-size: 16px;
+                  font-weight: 600;
+                }
+                &--like {
+                  font-size: 12px;
+                  color: #e54747;
+                  margin-right: 10px;
+                  display: inline;
+                }
+                &--name {
+                  color: #797979;
+                  font-size: 12px;
+                  display: inline;
+                }
+              }
+              img {
+                height: 65px;
+                width: 50px;
+              }
+            }
+          }
+        }
+      }
     }
   }
 }
 
-.like-btn {
-  .like-box {
-    font-size: 14px;
-    color: #e54747; 
-    &--color {
-      font-size: 14px;
-      color: #e54747;
-      display: inline;
-    }
-  }
-}

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -28,8 +28,9 @@ class BooksController < ApplicationController
   end
 
   def show
-    # binding.pry
     @selected_book = Book.find(params[:id])
+    @user = @selected_book.user_id
+    @recent_articles = Book.where(user_id: @selected_book.user_id).order('created_at DESC').limit(3)
   end
 
   # 親カテゴリーが選択された後に動くアクション

--- a/app/views/books/show.html.haml
+++ b/app/views/books/show.html.haml
@@ -10,9 +10,9 @@
         %h1.book-info__detail--title
           = @selected_book.book_title
         %p.book-info__detail--poster
-          = "田中 太郎"
+          = @selected_book.user.name
         %P.book-info__detail--post-date
-          = @selected_book.created_at
+          = @selected_book.created_at.strftime("%Y年%-m月%-d日 %-H時%-M分")
         %p.book-info__detail--review{ id: "star-evaluation-#{@selected_book.id}" }
           :javascript
             $('#star-evaluation-#{@selected_book.id}').raty({
@@ -36,3 +36,23 @@
       .like-btn
         .like-box
           = render partial: "like_ajax", locals: { book: @selected_book }
+    .recent
+      .poster-name
+        = "#{@selected_book.user.name}さんの最近の記事"
+      .recent-articles
+        %ul
+          - @recent_articles.each do |article|
+            .article-box
+              .article-container
+                = link_to book_path(article) do
+                  %li
+                    .article-info
+                      .article-data
+                        %p.article-data--title
+                          = article.book_title
+                        .article-data--like
+                          = icon('fas', 'heart')
+                          = article.likes.count
+                        .article-data--name
+                          = article.user.name
+                      = image_tag article.image.url

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,5 +15,6 @@ module BookHouse
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
+    config.time_zone = 'Tokyo'
   end
 end


### PR DESCRIPTION
# What
詳細ページにおける修正と表示内容追加
 - 投稿者の名前を仮置きしていたものから実際の投稿者の名前を表示するように修正
 - 投稿日時を日本時間に修正
 - 投稿者の最近の記事（直近の投稿3つ）を追加

# Why
 - 投稿者の名前と投稿日時を正確に表示するため
 - 投稿者の最近の記事を表示することで、閲覧者が興味を持った投稿者の他の記事を簡単に読めるようにするため