### PR TITLE
投稿した記事の削除機能実装

### DIFF
--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -12,4 +12,10 @@ class MypagesController < ApplicationController
     @like_count = Like.where(user_id: current_user.id).count
   end
 
+  def destroy
+    delete_book = Book.find(params[:id])
+    delete_book.destroy
+    redirect_to mypages_path
+  end
+
 end

--- a/app/views/mypages/index.html.haml
+++ b/app/views/mypages/index.html.haml
@@ -51,4 +51,5 @@
               %p.book-edit__edit
                 = link_to "編集", "#"
               %p.book-edit__delete
-                = link_to "削除", "#"
+                = link_to mypage_path(book.id), method: :delete, data: {confirm: "削除しますか？"} do
+                  = "削除"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,5 +12,5 @@ Rails.application.routes.draw do
   end
 
   resources :categories, only: [:show]
-  resources :mypages, only: [:index]
+  resources :mypages, only: [:index, :destroy]
 end


### PR DESCRIPTION
# What
過去に投稿した本の記事の削除機能を実装
 - マイページの削除をクリックすることで本の記事の削除が可能
 - 投稿者以外は削除することが出来ない
 - 本の記事が削除されると「いいね」も削除される
 - 削除後はマイページにリダイレクトされる

# Why
過去に投稿した記事を削除できるようにするため