### PR TITLE
投稿した記事の編集機能実装

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -33,6 +33,19 @@ class BooksController < ApplicationController
     @recent_articles = Book.where(user_id: @selected_book.user_id).order('created_at DESC').limit(3)
   end
 
+  def edit
+    @book = Book.find(params[:id])
+    @book_parent = Category.roots
+    @book_root_category = @book.category.root
+    @book_children_category = @book_root_category.children
+  end
+
+  def update
+    book = Book.find(params[:id])
+    book.update(book_params)
+    redirect_to book_path(book)
+  end
+
   # 親カテゴリーが選択された後に動くアクション
   def get_category_children
     #選択された親カテゴリーに紐付く子カテゴリーの配列を取得

--- a/app/views/books/edit.html.haml
+++ b/app/views/books/edit.html.haml
@@ -1,0 +1,49 @@
+.header-wrapper
+  = render "header"
+
+.new-wrapper
+  .new-main
+    = form_with model: @book, local: true do |f|
+      .book-container
+        = f.label :image, class: 'book-container__left' do
+          .prev-contents
+            - if @book.image.present?
+              .prev-content
+                = image_tag @book.image.url, alt: "preview", class: "prev-image"
+            - else
+              = image_tag '/assets/icon_camera.png', class: 'book-container__left__icon'
+              .book-container__left__comment
+                %pクリックして<br>
+                %pファイルをアップロード
+          = f.file_field :image, class: 'book-container__left__btn'
+        .book-container__right
+          .book-container__right__title
+            = f.label :book_title, "タイトル", class: 'book-container__right__title--label'
+          .book-container__right__title
+            = f.text_field :book_title, placeholder: 'タイトル', class: 'book-container__right__title--input'
+          .book-container__right__category
+            = f.label :category, "カテゴリー", class: 'book-container__right__category--label'
+          .book-container__right__category.js-category-form
+            = f.collection_select :category_id, @book_parent, :id, :name, {prompt: '選択してください',selected: Book.find(params[:id]).category.parent.id}, {class: 'book-container__right__category--input', id: 'parent-category'}
+          #child-wrapper
+            = f.collection_select :category_id, @book_children_category, :id, :name, {selected: Book.find(params[:id]).category.id}, {class: 'book-container__right__category--input'}
+          .book-container__right__review
+            .book-container__right__review--title
+              = "評価"
+            .evaluation{ id: :star }
+              = f.hidden_field :evaluation, id: :review_star
+              :javascript
+                $('#star').raty({
+                  starOff: "#{asset_path('star-off.png')}",
+                  starOn: "#{asset_path('star-on.png')}",
+                  starHalf: "#{asset_path('star-half.png')}",
+                  scoreName: 'book[evaluation]',
+                  half: true,
+                });
+      .book-article
+        .book-article__title
+          = f.text_area :article_title, placeholder: '記事タイトル', class: 'book-article__title--input'
+        .book-article__content
+          = f.text_area :article, placeholder: 'こちらに読んだ本の内容や感想を記録しましょう', class: 'book-article__content--input'
+      .book-register
+        = f.submit "更新する", class: 'book-register__btn'

--- a/app/views/mypages/index.html.haml
+++ b/app/views/mypages/index.html.haml
@@ -49,7 +49,7 @@
                         = "投稿日 #{book.created_at.strftime("%Y年 %m月 %d日")}"
             .book-edit
               %p.book-edit__edit
-                = link_to "編集", "#"
+                = link_to "編集", edit_book_path(book.id)
               %p.book-edit__delete
                 = link_to mypage_path(book.id), method: :delete, data: {confirm: "削除しますか？"} do
                   = "削除"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
     post 'users/guest_sign_in', to: 'users/sessions#new_guest'
   end
   root "books#index"
-  resources :books, only: [:index, :show, :new, :create] do
+  resources :books, only: [:index, :show, :new, :create, :edit, :update] do
     resource :likes, only: [:create, :destroy]
     collection do
       get 'get_category_children', defaults: { format: 'json' }


### PR DESCRIPTION
# What
過去に投稿した本の記事の編集機能を実装
 - マイページの編集をクリックすると記事の編集ページへ遷移
 - 投稿者以外は編集することが出来ない
 - 編集後は編集した記事の詳細ページにリダイレクトされる

# Why
過去に投稿した記事を編集できるようにするため