### PR TITLE
記事投稿ページの改良

### DIFF
--- a/app/assets/javascripts/auto_resize.js
+++ b/app/assets/javascripts/auto_resize.js
@@ -1,0 +1,11 @@
+$(function(){
+  $('textarea.auto-resize').on('change keyup keydown paste cut', function(){
+    if ($(this).outerHeight() > this.scrollHeight){
+      $(this).height(1)
+    }
+    while ($(this).outerHeight() < this.scrollHeight){
+      $(this).height($(this).height() + 1)
+    }
+  });
+});
+

--- a/app/assets/stylesheets/modules/_books_new.scss
+++ b/app/assets/stylesheets/modules/_books_new.scss
@@ -18,11 +18,10 @@ select::-ms-expand {
 
 .new-wrapper {
   height: 100vh;
-  // background-color: beige;
   .new-main {
-    // background-color: aquamarine;
     width: 620px;
     margin: 80px auto 0;
+    padding-bottom: 150px;
     .book-container {
       display: flex;
       padding-bottom: 60px;
@@ -103,7 +102,6 @@ select::-ms-expand {
           }
         }
         &__review {
-          // background-color: chartreuse;
           position: absolute;
           bottom: 10px;
             &--title {
@@ -117,7 +115,6 @@ select::-ms-expand {
       }
     }
     .book-article {
-      // background-color: burlywood;
       &__title {
         &--input {
           width: 100%;

--- a/app/views/books/new.html.haml
+++ b/app/views/books/new.html.haml
@@ -11,7 +11,7 @@
               .prev-content
                 = image_tag @book.image.url, alt: "preview", class: "prev-image"
             - else
-              = image_tag '/assets/icon_camera.png', class: 'book-container__left__icon'
+              = image_tag asset_path('icon_camera.png'), class: 'book-container__left__icon'
               .book-container__left__comment
                 %pクリックして<br>
                 %pファイルをアップロード
@@ -42,6 +42,6 @@
         .book-article__title
           = f.text_area :article_title, placeholder: '記事タイトル', class: 'book-article__title--input'
         .book-article__content
-          = f.text_area :article, placeholder: 'こちらに読んだ本の内容や感想を記録しましょう', class: 'book-article__content--input'
+          = f.text_area :article, placeholder: 'こちらに読んだ本の内容や感想を記録しましょう', class: 'book-article__content--input auto-resize'
       .book-register
         = f.submit "投稿する", class: 'book-register__btn'


### PR DESCRIPTION
# What
 - 記事の入力欄を入力内容に応じて自動拡張するように改良
 - 画像のpath指定の記述を変更

# Why
 - 記事投稿時に記述している内容の全体が見えるようしてユーザの利便性を向上させるため
 - 本番環境では対象の画像が読み込まれないため