### PR TITLE
編集ページの改良

### DIFF
--- a/app/assets/stylesheets/modules/_books_new.scss
+++ b/app/assets/stylesheets/modules/_books_new.scss
@@ -153,5 +153,19 @@ select::-ms-expand {
         padding: 8px 0;
       }
     }
+    .book-cancel {
+      margin-top: 30px;
+      text-align: center;
+      &__btn {
+        background-color: #797979;
+        color: #fff;
+        display: inline-block;
+        width: 300px;
+        padding: 8px 0;
+        font-size: 14px;
+        cursor: pointer;
+        border: none;
+      }
+    }
   }
 }

--- a/app/views/books/edit.html.haml
+++ b/app/views/books/edit.html.haml
@@ -44,6 +44,9 @@
         .book-article__title
           = f.text_area :article_title, placeholder: '記事タイトル', class: 'book-article__title--input'
         .book-article__content
-          = f.text_area :article, placeholder: 'こちらに読んだ本の内容や感想を記録しましょう', class: 'book-article__content--input'
+          = f.text_area :article, rows: 4, placeholder: 'こちらに読んだ本の内容や感想を記録しましょう', class: 'book-article__content--input auto-resize'
       .book-register
         = f.submit "更新する", class: 'book-register__btn'
+      .book-cancel
+        = link_to mypages_path, class: 'book-cancel__btn' do
+          = "キャンセル"


### PR DESCRIPTION
# What
 - 記事の入力欄を入力内容に応じて自動拡張するように改良
 - キャンセルボタンを追加。キャンセルボタンをクリックするとマイページに遷移

# Why
 - 記事編集時に記述している内容の全体が見えるようしてユーザの利便性を向上させるため
 - 編集をキャンセルするときにマイページに戻れるようにするため