### PR TITLE
おすすめページの追加

### DIFF
--- a/app/assets/stylesheets/modules/_books_index.scss
+++ b/app/assets/stylesheets/modules/_books_index.scss
@@ -149,7 +149,7 @@ nav.pagination {
       margin-bottom: 8px;
       color: #787c7b;
     }
-    .mani-category {
+    .main-category {
       font-size: 24px;
       font-weight: 700;
       letter-spacing: .04em;
@@ -188,7 +188,7 @@ nav.pagination {
                 overflow: hidden;
               }
               &__article {
-                font-size: 14px;
+                font-size: 13px;
                 letter-spacing: .04em;
                 color: #787c7b;
                 word-break: break-all;
@@ -204,6 +204,21 @@ nav.pagination {
                 bottom: 0;
                 font-size: 14px;
                 color: #e54747; 
+              }
+              .star-box {
+                display: flex;
+                float: right;
+                position: absolute;
+                bottom: 0;
+                right: 0;
+                img {
+                  height: 20px;
+                  width: 20px;
+                }
+                p {
+                  font-size: 16px;
+                  margin-left: 10px;
+                }
               }
             }
           }

--- a/app/assets/stylesheets/recommendations.scss
+++ b/app/assets/stylesheets/recommendations.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the recommendations controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/recommendations_controller.rb
+++ b/app/controllers/recommendations_controller.rb
@@ -1,0 +1,2 @@
+class RecommendationsController < ApplicationController
+end

--- a/app/controllers/recommendations_controller.rb
+++ b/app/controllers/recommendations_controller.rb
@@ -1,2 +1,14 @@
 class RecommendationsController < ApplicationController
+  
+  def index
+    @recommended_books = Book.order('evaluation DESC').order('created_at DESC').page(params[:page]).per(8)
+    @categories = Category.where(ancestry: nil)
+    @categories_1 = Category.where(ancestry: 1)
+    @categories_2 = Category.where(ancestry: 2)
+    @categories_3 = Category.where(ancestry: 3)
+    @categories_4 = Category.where(ancestry: 4)
+    @categories_5 = Category.where(ancestry: 5)
+    @categories_6 = Category.where(ancestry: 6)
+    @categories_7 = Category.where(ancestry: 7)
+  end
 end

--- a/app/helpers/recommendations_helper.rb
+++ b/app/helpers/recommendations_helper.rb
@@ -1,0 +1,2 @@
+module RecommendationsHelper
+end

--- a/app/views/books/_header.html.haml
+++ b/app/views/books/_header.html.haml
@@ -12,7 +12,7 @@
     %li.header__navi__menu--list
       = link_to "ホーム", root_path
     %li.header__navi__menu--list
-      = link_to "おすすめ"
+      = link_to "おすすめ", recommendations_path
     %li.header__navi__menu--list
       = link_to "コラム"
   - if user_signed_in?

--- a/app/views/books/_main_content.html.haml
+++ b/app/views/books/_main_content.html.haml
@@ -1,7 +1,7 @@
 .main-wrapper
   .main-header
     %p.breadcrumb
-    %h1.mani-category
+    %h1.main-category
       = "最新の記事"
   .main-content
     .book-list

--- a/app/views/categories/show.html.haml
+++ b/app/views/categories/show.html.haml
@@ -8,7 +8,7 @@
         = @category.parent.name
         >
         = @category.name
-      %h1.mani-category
+      %h1.main-category
         = @category.name
     .main-content
       .book-list

--- a/app/views/recommendations/index.html.haml
+++ b/app/views/recommendations/index.html.haml
@@ -1,0 +1,41 @@
+.header-wrapper
+  = render "books/header"
+.content-wrapper
+  = render "books/side_bar"
+
+  .main-wrapper
+    .main-header
+      %p.breadcrumb
+      %h1.main-category
+        = "おすすめの記事（星の数が多い順）"
+    .main-content
+      .book-list
+        %ul
+          - @recommended_books.each do |book|
+            = link_to book_path(book) do
+              %li
+                .book-img
+                  = image_tag book.image.url
+                .book-description
+                  .book-description__title
+                    = book.article_title
+                  .book-description__article
+                    = book.article
+                  .like-btn
+                    .like-box
+                      = icon('fas', 'heart')
+                      = book.likes.count
+                  .star-box
+                    %p.book-info__detail--review{ id: "star-evaluation-#{book.id}" }
+                      :javascript
+                        $('#star-evaluation-#{book.id}').raty({
+                          starOff: "#{asset_path('star-off.png')}",
+                          starOn: "#{asset_path('star-on.png')}",
+                          starHalf: "#{asset_path('star-half.png')}",
+                          half: true,
+                          readOnly: true,
+                          score: "#{book.evaluation}",
+                        });
+                    %p.book-info__detail--point
+                      = book.evaluation
+        = paginate @recommended_books

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,4 +13,5 @@ Rails.application.routes.draw do
 
   resources :categories, only: [:show]
   resources :mypages, only: [:index, :destroy]
+  resources :recommendations, only: [:index]
 end

--- a/test/controllers/recommendations_controller_test.rb
+++ b/test/controllers/recommendations_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class RecommendationsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# What
評価が高いおすすめの本の記事を集めたおすすページを作成
 - ヘッダーの「おすすめ」をクリックすると、おすすめページに遷移
 - おすすめページは星の数が多い順に表示

# Why
評価の高い順に並べたおすすめページを設けることでユーザがより良質な本の記事を探しやすくするため