### PR TITLE
詳細ページの記事に改行を反映

### DIFF
--- a/app/views/books/show.html.haml
+++ b/app/views/books/show.html.haml
@@ -32,7 +32,7 @@
       .post-info__title
         = @selected_book.article_title
       .post-info__article
-        = @selected_book.article
+        = safe_join(@selected_book.article.split("\n"),tag(:br))
       .like-btn
         .like-box
           = render partial: "like_ajax", locals: { book: @selected_book }


### PR DESCRIPTION
# What
詳細ページの記事の表示が投稿した時と同じ改行となるように変更

# Why
詳細ページの記事に改行が反映されていなかったため